### PR TITLE
inheritFromWidgetOfExactType is deprecated

### DIFF
--- a/lib/src/sliding_page.dart
+++ b/lib/src/sliding_page.dart
@@ -13,5 +13,5 @@ class SlidingPage extends InheritedWidget {
       old.page != page || old.notifier != notifier;
 
   static SlidingPage of(BuildContext context) =>
-      context.inheritFromWidgetOfExactType(SlidingPage);
+      context.dependOnInheritedWidgetOfExactType<SlidingPage>();
 }


### PR DESCRIPTION
since inheritFromWidgetOfExactType is deprecated inheritFromWidgetOfExactType should change to dependOnInheritedWidgetOfExactType