### PR TITLE
Avoid right margin for last indicator.

### DIFF
--- a/lib/src/sliding_indicator.dart
+++ b/lib/src/sliding_indicator.dart
@@ -54,7 +54,7 @@ class SlidingIndicator extends StatelessWidget {
                   return Container(
                     margin: EdgeInsets.only(
                       left: i == 0 ? 0 : margin,
-                      right: margin,
+                      right: i == indicatorCount - 1 ? 0 : margin,
                     ),
                     child: Container(
                       width: inactiveIndicatorSize,


### PR DESCRIPTION
Like first indicator does not have left margin, the last indicator should not have right margin.

Since the first indicator does not have a left margin, the last indicator should not have a right margin. Removing the right margin for the last indicator allows the sliding indicator to be perfectly centered horizontally.